### PR TITLE
Add support for homogenous dicts to extras.dynamodb

### DIFF
--- a/json_syntax/product.py
+++ b/json_syntax/product.py
@@ -55,7 +55,9 @@ class Attribute:
         self.is_required = is_required
 
     def __repr__(self):
-        return '<Attribute {!r}; {}>'.format(self.name, 'required' if self.is_required else 'optional')
+        return "<Attribute {!r}; {}>".format(
+            self.name, "required" if self.is_required else "optional"
+        )
 
 
 def is_attrs_field_required(field):
@@ -80,18 +82,22 @@ def attr_map(verb, outer, ctx, gen):
             try:
                 attr.typ = resolve_fwd_ref(attr.typ, outer)
             except TypeError:
-                failed.append('resolve fwd ref {} for {}'.format(attr.typ, attr.name))
+                failed.append("resolve fwd ref {} for {}".format(attr.typ, attr.name))
         if attr.inner is None:
-            attr.inner = ctx.lookup(verb=verb, typ=resolve_fwd_ref(attr.typ, outer), accept_missing=True)
+            attr.inner = ctx.lookup(
+                verb=verb, typ=resolve_fwd_ref(attr.typ, outer), accept_missing=True
+            )
         if attr.inner is None:
             if attr.typ is None:
-                failed.append('get fallback for {}'.format(attr.name))
+                failed.append("get fallback for {}".format(attr.name))
             else:
-                failed.append('get {} for {}'.format(attr.typ, attr.name))
+                failed.append("get {} for {}".format(attr.typ, attr.name))
         result.append(attr)
 
     if failed:
-        raise TypeError("{}({}) failed while trying to: {}".format(verb, outer, ', '.join(failed)))
+        raise TypeError(
+            "{}({}) failed while trying to: {}".format(verb, outer, ", ".join(failed))
+        )
     return tuple(result)
 
 
@@ -111,16 +117,21 @@ def build_attribute_map(verb, typ, ctx, read_all):
         else:
             fields = fields.values()
 
-    return attr_map(verb, typ, ctx, (
-        Attribute(
-            name=field.name,
-            typ=field.type,
-            is_required=is_attrs_field_required(field),
-            default=field.default,
-        )
-        for field in fields
-        if read_all or field.init
-    ))
+    return attr_map(
+        verb,
+        typ,
+        ctx,
+        (
+            Attribute(
+                name=field.name,
+                typ=field.type,
+                is_required=is_attrs_field_required(field),
+                default=field.default,
+            )
+            for field in fields
+            if read_all or field.init
+        ),
+    )
 
 
 def build_named_tuple_map(verb, typ, ctx):
@@ -152,15 +163,20 @@ def build_named_tuple_map(verb, typ, ctx):
     except AttributeError:
         pass
 
-    return attr_map(verb, typ, ctx, (
-        Attribute(
-            name=name,
-            typ=inner,
-            is_required=name not in defaults,
-            default=defaults.get(name, SENTINEL),
-        )
-        for name, inner in fields
-    ))
+    return attr_map(
+        verb,
+        typ,
+        ctx,
+        (
+            Attribute(
+                name=name,
+                typ=inner,
+                is_required=name not in defaults,
+                default=defaults.get(name, SENTINEL),
+            )
+            for name, inner in fields
+        ),
+    )
 
 
 def build_typed_dict_map(verb, typ, ctx):
@@ -176,12 +192,12 @@ def build_typed_dict_map(verb, typ, ctx):
     ):
         return
 
-    return attr_map(verb, typ, ctx, (
-        Attribute(
-            name=name,
-            typ=inner,
-            is_required=True,
-            default=SENTINEL,
-        )
-        for name, inner in typ.__annotations__.items()
-    ))
+    return attr_map(
+        verb,
+        typ,
+        ctx,
+        (
+            Attribute(name=name, typ=inner, is_required=True, default=SENTINEL)
+            for name, inner in typ.__annotations__.items()
+        ),
+    )

--- a/tests/extras/test_dynamodb.py
+++ b/tests/extras/test_dynamodb.py
@@ -5,7 +5,7 @@ from json_syntax.helpers import NoneType
 
 from fractions import Fraction
 from decimal import Decimal
-from typing import List, Set, Optional
+from typing import Dict, List, Optional, Set
 
 try:
     import attr
@@ -71,6 +71,16 @@ def test_list():
         "apple",
         "banana",
     ]
+
+
+def test_dict():
+    assert encode({"A": 1, "B": 2}, Dict[str, int]) == {
+        "M": {"A": {"N": "1"}, "B": {"N": "2"}}
+    }
+    assert decode({"M": {"A": {"N": "1"}, "B": {"N": "2"}}}, Dict[str, int]) == {
+        "A": 1,
+        "B": 2,
+    }
 
 
 def cheat(value):

--- a/tests/types_attrs_ann.py
+++ b/tests/types_attrs_ann.py
@@ -2,6 +2,7 @@ import attr
 from typing import NamedTuple
 
 from tests.types_attrs_noann import flat_types, hook_types, Hooks
+
 # Import for re-export
 from tests.types_attrs_noann import Named1, Named2  # noqa
 


### PR DESCRIPTION
Add a dicts rule. Working on this, I realized the nice way to do this (I use a hack in the main code) would be to add new verbs PY2STR and STR2PY since that's how we're really handling keys. Hmm...