### PR TITLE
Dynamodb improvements, fixes for TypedDict

### DIFF
--- a/json_syntax/action_v1.py
+++ b/json_syntax/action_v1.py
@@ -190,6 +190,20 @@ def convert_dict_to_attrs(value, pre_hook, inner_map, con):
     return con(**args)
 
 
+def convert_dict_to_dict(value, inner_map, con):
+    args = {}
+    for attr in inner_map:
+        with ErrorContext("[{!r}]".format(attr.name)):
+            try:
+                arg = value[attr.name]
+            except KeyError:
+                if attr.is_required:
+                    raise KeyError("Missing key") from None
+            else:
+                args[attr.name] = attr.inner(arg)
+    return con(args)
+
+
 def check_dict(value, inner_map, pre_hook):
     value = pre_hook(value)
     if not isinstance(value, dict):

--- a/json_syntax/attrs.py
+++ b/json_syntax/attrs.py
@@ -4,6 +4,7 @@ from .action_v1 import (
     check_isinst,
     check_tuple_as_list,
     convert_attrs_to_dict,
+    convert_dict_to_dict,
     convert_dict_to_attrs,
     convert_tuple_as_list,
 )

--- a/json_syntax/extras/dynamodb.py
+++ b/json_syntax/extras/dynamodb.py
@@ -261,7 +261,7 @@ class DynamodbRuleSet(SimpleRuleSet):
         inner = self.lookup(verb=PY2DDB, typ=typ)
         return partial(unwrap_item, inner=inner)
 
-    def ad_hoc(self, _key_prefix='', **kw):
+    def ad_hoc(self, _key_prefix="", **kw):
         """
         Convenience method to encode an ad hoc set of arguments used in various DynamoDB APIs.
 
@@ -380,7 +380,7 @@ def encode_null(value):
     if not value:
         return {"NULL": True}
     else:
-        raise ValueError('{} is not None'.format(value))
+        raise ValueError("{} is not None".format(value))
 
 
 def decode_boolean(value):
@@ -517,7 +517,7 @@ def encode_string_set(value):
 
 
 def wrap_item(item, inner):
-    return inner({'M': item})
+    return inner({"M": item})
 
 
 def unwrap_item(value, inner):

--- a/json_syntax/product.py
+++ b/json_syntax/product.py
@@ -77,22 +77,22 @@ def is_attrs_field_required(field):
 def attr_map(verb, outer, ctx, gen):
     result = []
     failed = []
-    for attr in gen:
-        if attr.typ is not None:
+    for att in gen:
+        if att.typ is not None:
             try:
-                attr.typ = resolve_fwd_ref(attr.typ, outer)
+                att.typ = resolve_fwd_ref(att.typ, outer)
             except TypeError:
-                failed.append("resolve fwd ref {} for {}".format(attr.typ, attr.name))
-        if attr.inner is None:
-            attr.inner = ctx.lookup(
-                verb=verb, typ=resolve_fwd_ref(attr.typ, outer), accept_missing=True
+                failed.append("resolve fwd ref {} for {}".format(att.typ, att.name))
+        if att.inner is None:
+            att.inner = ctx.lookup(
+                verb=verb, typ=resolve_fwd_ref(att.typ, outer), accept_missing=True
             )
-        if attr.inner is None:
-            if attr.typ is None:
-                failed.append("get fallback for {}".format(attr.name))
+        if att.inner is None:
+            if att.typ is None:
+                failed.append("get fallback for {}".format(att.name))
             else:
-                failed.append("get {} for {}".format(attr.typ, attr.name))
-        result.append(attr)
+                failed.append("get {} for {}".format(att.typ, att.name))
+        result.append(att)
 
     if failed:
         raise TypeError(

--- a/tests/extras/test_dynamodb.py
+++ b/tests/extras/test_dynamodb.py
@@ -100,7 +100,7 @@ def test_dict():
 def cheat(value):
     if isinstance(value, dict):
         for key, val in value.items():
-            if key in ('SS', 'NS', 'BS'):
+            if key in ("SS", "NS", "BS"):
                 val.sort()
             else:
                 cheat(val)
@@ -196,44 +196,44 @@ def test_item2():
 def test_ad_hoc_atoms():
     rs = dynamodb_ruleset()
     actual = rs.ad_hoc(
-        ':',
+        ":",
         arg_null=None,
         arg_bool=False,
         arg_int=3,
         arg_float=6.6,
-        arg_dec=Decimal('-7.888'),
-        arg_str='some_string',
-        arg_bytes=b'some_byes',
+        arg_dec=Decimal("-7.888"),
+        arg_str="some_string",
+        arg_bytes=b"some_byes",
         arg_class=Outer(stuff=Inner(name="bob")),
     )
     assert actual == {
-        ':arg_bool': {'BOOL': False},
-        ':arg_bytes': {'B': 'c29tZV9ieWVz'},
-        ':arg_dec': {'N': '-7.888'},
-        ':arg_float': {'N': '6.6'},
-        ':arg_int': {'N': '3'},
-        ':arg_null': {'NULL': True},
-        ':arg_str': {'S': 'some_string'},
-        ':arg_class': {'M': {'stuff': {'M': {'name': {'S': 'bob'}}}}},
+        ":arg_bool": {"BOOL": False},
+        ":arg_bytes": {"B": "c29tZV9ieWVz"},
+        ":arg_dec": {"N": "-7.888"},
+        ":arg_float": {"N": "6.6"},
+        ":arg_int": {"N": "3"},
+        ":arg_null": {"NULL": True},
+        ":arg_str": {"S": "some_string"},
+        ":arg_class": {"M": {"stuff": {"M": {"name": {"S": "bob"}}}}},
     }
 
 
 def test_ad_hoc_typed():
     rs = dynamodb_ruleset()
     actual = rs.ad_hoc(
-        ':',
+        ":",
         arg_opt1=(None, Optional[int]),
         arg_opt2=(5, Optional[int]),
         arg_list=([3, 2.2, 6.0], List[float]),
         arg_tup=((3, 2.2, 6.0), Tuple[float, ...]),
         arg_class=(Outer(stuff=Inner(name="bob")), Outer),
-        arg_str_set=({'foo', 'bar', 'qux'}, Set[str])
+        arg_str_set=({"foo", "bar", "qux"}, Set[str]),
     )
     assert cheat(actual) == {
-        ':arg_opt1': {'NULL': True},
-        ':arg_opt2': {'N': '5'},
-        ':arg_list': {'L': [{'N': '3'}, {'N': '2.2'}, {'N': '6.0'}]},
-        ':arg_tup': {'L': [{'N': '3'}, {'N': '2.2'}, {'N': '6.0'}]},
-        ':arg_class': {'M': {'stuff': {'M': {'name': {'S': 'bob'}}}}},
-        ':arg_str_set': {'SS': ['bar', 'foo', 'qux']},
+        ":arg_opt1": {"NULL": True},
+        ":arg_opt2": {"N": "5"},
+        ":arg_list": {"L": [{"N": "3"}, {"N": "2.2"}, {"N": "6.0"}]},
+        ":arg_tup": {"L": [{"N": "3"}, {"N": "2.2"}, {"N": "6.0"}]},
+        ":arg_class": {"M": {"stuff": {"M": {"name": {"S": "bob"}}}}},
+        ":arg_str_set": {"SS": ["bar", "foo", "qux"]},
     }

--- a/tests/extras/test_dynamodb.py
+++ b/tests/extras/test_dynamodb.py
@@ -37,8 +37,8 @@ def test_optional():
 
 
 def test_null():
-    assert encode(None, type(None)) == {"NULL": True}
-    assert decode({"NULL": True}, type(None)) is None
+    assert encode(None, NoneType) == {"NULL": True}
+    assert decode({"NULL": True}, NoneType) is None
 
 
 def test_bool():

--- a/tests/test_attrs.py
+++ b/tests/test_attrs.py
@@ -10,9 +10,25 @@ except ImportError:
 from typing import Tuple
 
 try:
-    from tests.types_attrs_ann import flat_types, hook_types, Named1, Named2, Named3, Dict1, Dict2
+    from tests.types_attrs_ann import (
+        flat_types,
+        hook_types,
+        Named1,
+        Named2,
+        Named3,
+        Dict1,
+        Dict2,
+    )
 except SyntaxError:
-    from tests.types_attrs_noann import flat_types, hook_types, Named1, Named2, Named3, Dict1, Dict2
+    from tests.types_attrs_noann import (
+        flat_types,
+        hook_types,
+        Named1,
+        Named2,
+        Named3,
+        Dict1,
+        Dict2,
+    )
 
 
 class Fail:
@@ -226,35 +242,35 @@ def test_tuples_encoding():
     assert not inspect({})
 
 
-@pytest.mark.parametrize('dict_type,reason', [
-    (Dict1, "TypedDict unavailable"),
-    (Dict2, "TypedDict or annotations unavailable"),
-])
+@pytest.mark.parametrize(
+    "dict_type,reason",
+    [(Dict1, "TypedDict unavailable"), (Dict2, "TypedDict or annotations unavailable")],
+)
 def test_typed_dict_encoding(dict_type, reason):
     "Test that typed_dicts encodes and decodes a typed dict."
     if dict_type is None:
         pytest.skip(reason)
 
     encoder = at.typed_dicts(verb=PY2JSON, typ=dict_type, ctx=Ctx())
-    assert encoder({'a': 3, 'b': 'foo'}) == {'a': 3, 'b': 'foo'}
-    assert encoder({'a': 3, 'b': 'foo', 'c': 'extra'}) == {'a': 3, 'b': 'foo'}
-    assert encoder({'a': 3.2, 'b': 5}) == {'a': 3, 'b': '5'}
+    assert encoder({"a": 3, "b": "foo"}) == {"a": 3, "b": "foo"}
+    assert encoder({"a": 3, "b": "foo", "c": "extra"}) == {"a": 3, "b": "foo"}
+    assert encoder({"a": 3.2, "b": 5}) == {"a": 3, "b": "5"}
 
     decoder = at.typed_dicts(verb=JSON2PY, typ=dict_type, ctx=Ctx())
-    assert decoder({'a': 3, 'b': 'foo'}) == {'a': 3, 'b': 'foo'}
-    assert decoder({'a': 3, 'b': 'foo', 'c': 'extra'}) == {'a': 3, 'b': 'foo'}
-    assert decoder({'a': 3.2, 'b': 5}) == {'a': 3, 'b': '5'}
+    assert decoder({"a": 3, "b": "foo"}) == {"a": 3, "b": "foo"}
+    assert decoder({"a": 3, "b": "foo", "c": "extra"}) == {"a": 3, "b": "foo"}
+    assert decoder({"a": 3.2, "b": 5}) == {"a": 3, "b": "5"}
 
     inspect = at.typed_dicts(verb=INSP_PY, typ=dict_type, ctx=Ctx())
-    assert inspect({'a': 3, 'b': 'foo'})
-    assert not inspect({'a': 3.2, 'b': False})
+    assert inspect({"a": 3, "b": "foo"})
+    assert not inspect({"a": 3.2, "b": False})
     assert not inspect("foo")
     assert not inspect({})
-    assert inspect({'a': 3, 'b': 'foo', 'c': True})
+    assert inspect({"a": 3, "b": "foo", "c": True})
 
     inspect = at.typed_dicts(verb=INSP_JSON, typ=dict_type, ctx=Ctx())
-    assert inspect({'a': 3, 'b': 'foo'})
-    assert not inspect({'a': 3.2, 'b': False})
+    assert inspect({"a": 3, "b": "foo"})
+    assert not inspect({"a": 3.2, "b": False})
     assert not inspect("foo")
     assert not inspect({})
-    assert inspect({'a': 3, 'b': 'foo', 'c': True})
+    assert inspect({"a": 3, "b": "foo", "c": True})

--- a/tests/test_attrs.py
+++ b/tests/test_attrs.py
@@ -10,9 +10,9 @@ except ImportError:
 from typing import Tuple
 
 try:
-    from tests.types_attrs_ann import flat_types, hook_types, Named1, Named2, Named3
+    from tests.types_attrs_ann import flat_types, hook_types, Named1, Named2, Named3, Dict1, Dict2
 except SyntaxError:
-    from tests.types_attrs_noann import flat_types, hook_types, Named1, Named2, Named3
+    from tests.types_attrs_noann import flat_types, hook_types, Named1, Named2, Named3, Dict1, Dict2
 
 
 class Fail:
@@ -224,3 +224,37 @@ def test_tuples_encoding():
     assert not inspect(["str", "foo"])
     assert not inspect([33, "foo", None])
     assert not inspect({})
+
+
+@pytest.mark.parametrize('dict_type,reason', [
+    (Dict1, "TypedDict unavailable"),
+    (Dict2, "TypedDict or annotations unavailable"),
+])
+def test_typed_dict_encoding(dict_type, reason):
+    "Test that typed_dicts encodes and decodes a typed dict."
+    if dict_type is None:
+        pytest.skip(reason)
+
+    encoder = at.typed_dicts(verb=PY2JSON, typ=dict_type, ctx=Ctx())
+    assert encoder({'a': 3, 'b': 'foo'}) == {'a': 3, 'b': 'foo'}
+    assert encoder({'a': 3, 'b': 'foo', 'c': 'extra'}) == {'a': 3, 'b': 'foo'}
+    assert encoder({'a': 3.2, 'b': 5}) == {'a': 3, 'b': '5'}
+
+    decoder = at.typed_dicts(verb=JSON2PY, typ=dict_type, ctx=Ctx())
+    assert decoder({'a': 3, 'b': 'foo'}) == {'a': 3, 'b': 'foo'}
+    assert decoder({'a': 3, 'b': 'foo', 'c': 'extra'}) == {'a': 3, 'b': 'foo'}
+    assert decoder({'a': 3.2, 'b': 5}) == {'a': 3, 'b': '5'}
+
+    inspect = at.typed_dicts(verb=INSP_PY, typ=dict_type, ctx=Ctx())
+    assert inspect({'a': 3, 'b': 'foo'})
+    assert not inspect({'a': 3.2, 'b': False})
+    assert not inspect("foo")
+    assert not inspect({})
+    assert inspect({'a': 3, 'b': 'foo', 'c': True})
+
+    inspect = at.typed_dicts(verb=INSP_JSON, typ=dict_type, ctx=Ctx())
+    assert inspect({'a': 3, 'b': 'foo'})
+    assert not inspect({'a': 3.2, 'b': False})
+    assert not inspect("foo")
+    assert not inspect({})
+    assert inspect({'a': 3, 'b': 'foo', 'c': True})

--- a/tests/types_attrs_ann.py
+++ b/tests/types_attrs_ann.py
@@ -1,15 +1,17 @@
 import attr
 from typing import NamedTuple
 
-from tests.types_attrs_noann import flat_types, hook_types, Hooks
-
-# Import for re-export
-from tests.types_attrs_noann import Named1, Named2  # noqa
+from tests.types_attrs_noann import flat_types, hook_types, Hooks, Dict1, Named1, Named2  # noqa
 
 try:
     from dataclasses import dataclass
 except ImportError:
     dataclass = None
+
+try:
+    from typing import TypedDict
+except ImportError:
+    TypedDict = None
 
 
 @attr.s(auto_attribs=True)
@@ -49,3 +51,11 @@ if dataclass:
 class Named3(NamedTuple):
     a: int
     b: str = "default"
+
+
+if TypedDict:
+    class Dict2(TypedDict):
+        a: int
+        b: str
+else:
+    Dict2 = None

--- a/tests/types_attrs_ann.py
+++ b/tests/types_attrs_ann.py
@@ -1,14 +1,14 @@
 import attr
 from typing import NamedTuple
 
-from tests.types_attrs_noann import (
+from tests.types_attrs_noann import (  # noqa
     flat_types,
     hook_types,
     Hooks,
     Dict1,
     Named1,
     Named2,
-)  # noqa
+)
 
 try:
     from dataclasses import dataclass

--- a/tests/types_attrs_ann.py
+++ b/tests/types_attrs_ann.py
@@ -1,7 +1,14 @@
 import attr
 from typing import NamedTuple
 
-from tests.types_attrs_noann import flat_types, hook_types, Hooks, Dict1, Named1, Named2  # noqa
+from tests.types_attrs_noann import (
+    flat_types,
+    hook_types,
+    Hooks,
+    Dict1,
+    Named1,
+    Named2,
+)  # noqa
 
 try:
     from dataclasses import dataclass
@@ -53,9 +60,9 @@ class Named3(NamedTuple):
     b: str = "default"
 
 
+Dict2 = None
 if TypedDict:
+
     class Dict2(TypedDict):
         a: int
         b: str
-else:
-    Dict2 = None

--- a/tests/types_attrs_noann.py
+++ b/tests/types_attrs_noann.py
@@ -1,6 +1,11 @@
 import attr
 from collections import namedtuple
 
+try:
+    from typing import TypedDict
+except ImportError:
+    TypedDict = None
+
 
 @attr.s
 class Flat1:
@@ -33,9 +38,19 @@ class Hook1(Hooks):
 
 
 hook_types = [Hook1]
+
 Named1 = namedtuple("Named1", ["a", "b"])
+named_tup_types = [Named1]
 try:
     Named2 = namedtuple("Named2", ["a", "b"], defaults=["default"])
+    named_tup_types.append(Named2)
 except TypeError:
     Named2 = None
 Named3 = None
+
+if TypedDict:
+    Dict1 = TypedDict('Dict1', a=int, b=str)
+    typed_dict_types.append(Dict1)
+else:
+    Dict1 = None
+Dict2 = None

--- a/tests/types_attrs_noann.py
+++ b/tests/types_attrs_noann.py
@@ -49,8 +49,7 @@ except TypeError:
 Named3 = None
 
 if TypedDict:
-    Dict1 = TypedDict('Dict1', a=int, b=str)
-    typed_dict_types.append(Dict1)
+    Dict1 = TypedDict("Dict1", a=int, b=str)
 else:
     Dict1 = None
 Dict2 = None


### PR DESCRIPTION
After using the dynamodb extras for a while, I've found some simple methods that make it far more practical. DDB doesn't actually treat a record as an M type, but it's convenient to use an `attrs` class as such, so I've added methods that wrap and unwrap them properly. Also, if your logic lives in `update_item` calls, you'll want to be able to create ExpressionAttributeValues arguments easily.

Also, TypedDict didn't work; that's fixed now.