### PR TITLE
Add string types

### DIFF
--- a/json_syntax/__init__.py
+++ b/json_syntax/__init__.py
@@ -22,6 +22,7 @@ from .std import (  # noqa
 )
 from .attrs import attrs_classes, named_tuples, tuples
 from .unions import unions
+from .string import stringify_keys
 from .helpers import JSON2PY, PY2JSON, INSP_PY, INSP_JSON, PATTERN  # noqa
 
 
@@ -55,6 +56,7 @@ def std_ruleset(
         named_tuples,
         tuples,
         dicts,
+        stringify_keys,
         unions,
         *extras,
         cache=cache,

--- a/json_syntax/attrs.py
+++ b/json_syntax/attrs.py
@@ -47,7 +47,7 @@ def attrs_classes(
     """
     if verb not in _SUPPORTED_VERBS:
         return
-    inner_map = build_attribute_map(verb, typ, ctx, read_all=verb == PY2JSON)
+    inner_map = build_attribute_map(verb, typ, ctx)
     if inner_map is None:
         return
 

--- a/json_syntax/helpers.py
+++ b/json_syntax/helpers.py
@@ -9,6 +9,9 @@ JSON2PY = "json_to_python"
 PY2JSON = "python_to_json"
 INSP_JSON = "inspect_json"
 INSP_PY = "inspect_python"
+INSP_STR = "inspect_string"
+STR2PY = "string_to_python"
+PY2STR = "python_to_string"
 PATTERN = "show_pattern"
 NoneType = type(None)
 SENTINEL = object()
@@ -173,7 +176,7 @@ class _Context:
 
     def __str__(self):
         return "{}{}{}".format(
-            self.original, self.lead, "".join(reversed(self.context))
+            self.original, self.lead, "".join(map(str, reversed(self.context)))
         )
 
     def __repr__(self):

--- a/json_syntax/product.py
+++ b/json_syntax/product.py
@@ -101,7 +101,7 @@ def attr_map(verb, outer, ctx, gen):
     return tuple(result)
 
 
-def build_attribute_map(verb, typ, ctx, read_all):
+def build_attribute_map(verb, typ, ctx):
     """
     Examine an attrs or dataclass type and construct a list of attributes.
 
@@ -129,7 +129,7 @@ def build_attribute_map(verb, typ, ctx, read_all):
                 default=field.default,
             )
             for field in fields
-            if read_all or field.init
+            if field.init
         ),
     )
 

--- a/json_syntax/string.py
+++ b/json_syntax/string.py
@@ -29,7 +29,7 @@ See std.dicts for an example.
 def stringify_keys(verb, typ, ctx):
     if verb not in (STR2PY, PY2STR, INSP_STR):
         return
-    if typ in (str, int, bool):
+    if typ in (str, int):
         if verb == STR2PY:
             return typ
         elif verb == PY2STR:

--- a/json_syntax/string.py
+++ b/json_syntax/string.py
@@ -1,0 +1,56 @@
+from .action_v1 import (
+    check_parse_error,
+    check_str_enum,
+    convert_date,
+    convert_enum_str,
+    convert_str_enum,
+)
+from .helpers import STR2PY, PY2STR, INSP_STR, issub_safe
+
+from datetime import date
+from enum import Enum
+from functools import partial
+
+
+"""
+As JSON requires string keys, unless dicts are only allowed to be Dict[str, T], we need to be able to encode
+values as strings.
+
+Recommendations:
+
+* The string verbs are not intended for direct use.
+* Use these verbs for any type that must be represented as a key in a JSON object.
+* The standard rules will only handle types that are reliable keys and have obvious string encodings.
+
+See std.dicts for an example.
+"""
+
+
+def stringify_keys(verb, typ, ctx):
+    if verb not in (STR2PY, PY2STR, INSP_STR):
+        return
+    if typ in (str, int, bool):
+        if verb == STR2PY:
+            return typ
+        elif verb == PY2STR:
+            return str
+        elif verb == INSP_STR:
+            return partial(check_parse_error, parser=typ, error=ValueError)
+    elif typ == date:
+        if verb == PY2STR:
+            return typ.isoformat
+        elif verb in (STR2PY, INSP_STR):
+            parse = convert_date
+            if verb == STR2PY:
+                return parse
+            else:
+                return partial(
+                    check_parse_error, parser=parse, error=(TypeError, ValueError)
+                )
+    elif issub_safe(typ, Enum):
+        if verb == PY2STR:
+            return partial(convert_enum_str, typ=typ)
+        elif verb == STR2PY:
+            return partial(convert_str_enum, typ=typ)
+        elif verb == INSP_STR:
+            return partial(check_str_enum, typ=typ)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "json-syntax"
-version = "2.0.2"
+version = "2.1.0"
 description = "Generates functions to convert Python classes to JSON dumpable objects."
 authors = ["Ben Samuel <bsamuel@unitedincome.com>"]
 license = "MIT"

--- a/tests/test_std.py
+++ b/tests/test_std.py
@@ -3,11 +3,11 @@ from unittest.mock import Mock
 
 from json_syntax import std
 from json_syntax.helpers import JSON2PY, PY2JSON, INSP_PY, INSP_JSON, NoneType
+from json_syntax.string import stringify_keys
 
 from datetime import datetime, date
 from decimal import Decimal
 from enum import Enum, IntEnum
-from functools import partial
 import math
 from typing import Optional, Union, Tuple, List, Set, FrozenSet, Dict
 from pickle import dumps
@@ -18,8 +18,19 @@ except ImportError:
     OrderedDict = None
 
 
-def Fail():
-    return Mock(lookup=Mock(side_effect=RuntimeError))
+class Rules:
+    def __init__(self, *rules):
+        self.rules = rules
+
+    def lookup(self, verb, typ, accept_missing=False):
+        for rule in self.rules:
+            result = rule(verb=verb, typ=typ, ctx=self)
+            if result is not None:
+                return result
+        if accept_missing:
+            return None
+        else:
+            raise RuntimeError("No rule for verb={}, typ={}".format(verb, typ))
 
 
 Mystery = Tuple["Mystery", "Thing"]
@@ -28,25 +39,25 @@ Mystery = Tuple["Mystery", "Thing"]
 def test_atoms_disregard():
     "Test the atoms rule will disregard unknown types and verbs."
 
-    assert std.atoms(verb="unknown", typ=str, ctx=Fail()) is None
+    assert std.atoms(verb="unknown", typ=str, ctx=Rules()) is None
     for verb in (JSON2PY, PY2JSON, INSP_PY, INSP_JSON):
-        assert std.atoms(verb=verb, typ=Mystery, ctx=Fail()) is None
+        assert std.atoms(verb=verb, typ=Mystery, ctx=Rules()) is None
 
 
 def test_atoms_str():
     "Test the atoms rule will generate encoders and decoders for strings."
 
-    decoder = std.atoms(verb=JSON2PY, typ=str, ctx=Fail())
+    decoder = std.atoms(verb=JSON2PY, typ=str, ctx=Rules())
     assert decoder("some string") == "some string"
 
-    encoder = std.atoms(verb=PY2JSON, typ=str, ctx=Fail())
+    encoder = std.atoms(verb=PY2JSON, typ=str, ctx=Rules())
     assert encoder("some string") == "some string"
 
-    inspect = std.atoms(verb=INSP_PY, typ=str, ctx=Fail())
+    inspect = std.atoms(verb=INSP_PY, typ=str, ctx=Rules())
     assert inspect("string")
     assert not inspect(5)
 
-    inspect = std.atoms(verb=INSP_JSON, typ=str, ctx=Fail())
+    inspect = std.atoms(verb=INSP_JSON, typ=str, ctx=Rules())
     assert inspect("string")
     assert not inspect(5)
 
@@ -54,17 +65,17 @@ def test_atoms_str():
 def test_atoms_int():
     "Test the atoms rule will generate encoders and decoders for integers."
 
-    decoder = std.atoms(verb=JSON2PY, typ=int, ctx=Fail())
+    decoder = std.atoms(verb=JSON2PY, typ=int, ctx=Rules())
     assert decoder(77) == 77
 
-    encoder = std.atoms(verb=PY2JSON, typ=int, ctx=Fail())
+    encoder = std.atoms(verb=PY2JSON, typ=int, ctx=Rules())
     assert encoder(77) == 77
 
-    inspect = std.atoms(verb=INSP_PY, typ=int, ctx=Fail())
+    inspect = std.atoms(verb=INSP_PY, typ=int, ctx=Rules())
     assert not inspect("string")
     assert inspect(5)
 
-    inspect = std.atoms(verb=INSP_JSON, typ=int, ctx=Fail())
+    inspect = std.atoms(verb=INSP_JSON, typ=int, ctx=Rules())
     assert not inspect("string")
     assert inspect(5)
 
@@ -72,19 +83,19 @@ def test_atoms_int():
 def test_atoms_bool():
     "Test the atoms rule will generate encoders and decoders for booleans."
 
-    decoder = std.atoms(verb=JSON2PY, typ=bool, ctx=Fail())
+    decoder = std.atoms(verb=JSON2PY, typ=bool, ctx=Rules())
     assert decoder(False) is False
     assert decoder(True) is True
 
-    encoder = std.atoms(verb=PY2JSON, typ=bool, ctx=Fail())
+    encoder = std.atoms(verb=PY2JSON, typ=bool, ctx=Rules())
     assert encoder(False) is False
     assert encoder(True) is True
 
-    inspect = std.atoms(verb=INSP_PY, typ=bool, ctx=Fail())
+    inspect = std.atoms(verb=INSP_PY, typ=bool, ctx=Rules())
     assert not inspect("string")
     assert inspect(True)
 
-    inspect = std.atoms(verb=INSP_JSON, typ=bool, ctx=Fail())
+    inspect = std.atoms(verb=INSP_JSON, typ=bool, ctx=Rules())
     assert not inspect("string")
     assert inspect(False)
 
@@ -92,21 +103,21 @@ def test_atoms_bool():
 def test_atoms_null():
     "Test the atoms rule will generate encoders and decoders for None / null."
 
-    decoder = std.atoms(verb=JSON2PY, typ=NoneType, ctx=Fail())
+    decoder = std.atoms(verb=JSON2PY, typ=NoneType, ctx=Rules())
     assert decoder(None) is None
     with pytest.raises(ValueError):
         decoder(5)
 
-    encoder = std.atoms(verb=PY2JSON, typ=NoneType, ctx=Fail())
+    encoder = std.atoms(verb=PY2JSON, typ=NoneType, ctx=Rules())
     assert encoder(None) is None
     with pytest.raises(ValueError):
         encoder(5)
 
-    inspect = std.atoms(verb=INSP_PY, typ=NoneType, ctx=Fail())
+    inspect = std.atoms(verb=INSP_PY, typ=NoneType, ctx=Rules())
     assert inspect(None)
     assert not inspect(0)
 
-    inspect = std.atoms(verb=INSP_JSON, typ=NoneType, ctx=Fail())
+    inspect = std.atoms(verb=INSP_JSON, typ=NoneType, ctx=Rules())
     assert inspect(None)
     assert not inspect(0)
 
@@ -115,7 +126,7 @@ def test_atoms_picklable():
     "Test that actions generated by the atoms rule can be pickled."
 
     actions = [
-        std.atoms(verb=verb, typ=typ, ctx=Fail())
+        std.atoms(verb=verb, typ=typ, ctx=Rules())
         for verb in [JSON2PY, PY2JSON, INSP_PY, INSP_JSON]
         for typ in [str, int, bool, NoneType]
     ]
@@ -126,32 +137,32 @@ def test_atoms_picklable():
 def test_floats_disregard():
     "Test the floats rule will disregard unknown types and verbs."
 
-    assert std.floats(verb="unknown", typ=str, ctx=Fail()) is None
+    assert std.floats(verb="unknown", typ=str, ctx=Rules()) is None
     for verb in (JSON2PY, PY2JSON, INSP_PY, INSP_JSON):
-        assert std.floats(verb=verb, typ=Mystery, ctx=Fail()) is None
+        assert std.floats(verb=verb, typ=Mystery, ctx=Rules()) is None
 
 
 def test_floats():
     "Test the floats rule will generate encoders and decoders for floats that are tolerant of integers."
 
-    decoder = std.floats(verb=JSON2PY, typ=float, ctx=Fail())
+    decoder = std.floats(verb=JSON2PY, typ=float, ctx=Rules())
     assert decoder(77.7) == 77.7
     assert decoder(77) == 77.0
     assert math.isnan(decoder("nan"))
     assert math.isnan(decoder(float("nan")))
 
-    encoder = std.floats(verb=PY2JSON, typ=float, ctx=Fail())
+    encoder = std.floats(verb=PY2JSON, typ=float, ctx=Rules())
     assert encoder(77.7) == 77.7
     assert encoder(float("inf")) == float("inf")
 
-    inspect = std.floats(verb=INSP_PY, typ=float, ctx=Fail())
+    inspect = std.floats(verb=INSP_PY, typ=float, ctx=Rules())
     assert not inspect("string")
     assert not inspect("-inf")
     assert inspect(float("-inf"))
     assert not inspect(44)
     assert inspect(77.7)
 
-    inspect = std.floats(verb=INSP_JSON, typ=float, ctx=Fail())
+    inspect = std.floats(verb=INSP_JSON, typ=float, ctx=Rules())
     assert not inspect("string")
     assert not inspect("-inf")
     assert inspect(float("-inf"))
@@ -162,24 +173,24 @@ def test_floats():
 def test_floats_nan_str():
     "Test the floats rule will generate encoders and decoders for floats that are tolerant of integers."
 
-    decoder = std.floats_nan_str(verb=JSON2PY, typ=float, ctx=Fail())
+    decoder = std.floats_nan_str(verb=JSON2PY, typ=float, ctx=Rules())
     assert decoder(77.7) == 77.7
     assert decoder(77) == 77.0
     assert math.isnan(decoder("nan"))
     assert math.isnan(decoder(float("nan")))
 
-    encoder = std.floats_nan_str(verb=PY2JSON, typ=float, ctx=Fail())
+    encoder = std.floats_nan_str(verb=PY2JSON, typ=float, ctx=Rules())
     assert encoder(77.7) == 77.7
     assert encoder(float("inf")) == "Infinity"
 
-    inspect = std.floats_nan_str(verb=INSP_PY, typ=float, ctx=Fail())
+    inspect = std.floats_nan_str(verb=INSP_PY, typ=float, ctx=Rules())
     assert not inspect("string")
     assert not inspect("-inf")
     assert inspect(float("-inf"))
     assert not inspect(44)
     assert inspect(77.7)
 
-    inspect = std.floats_nan_str(verb=INSP_JSON, typ=float, ctx=Fail())
+    inspect = std.floats_nan_str(verb=INSP_JSON, typ=float, ctx=Rules())
     assert not inspect("string")
     assert not inspect("-inf")
     assert inspect(float("-inf"))
@@ -191,7 +202,7 @@ def test_floats_picklable():
     "Test that actions generated by the floats rule can be pickled."
 
     actions = [
-        rule(verb=verb, typ=float, ctx=Fail())
+        rule(verb=verb, typ=float, ctx=Rules())
         for verb in [JSON2PY, PY2JSON, INSP_PY, INSP_JSON]
         for rule in (std.floats, std.floats_nan_str)
     ]
@@ -202,30 +213,30 @@ def test_floats_picklable():
 def test_decimals_disregard():
     "Test the decimals rule will disregard unknown types and verbs."
 
-    assert std.decimals(verb="unknown", typ=date, ctx=Fail()) is None
-    assert std.decimals(verb=JSON2PY, typ=Mystery, ctx=Fail()) is None
-    assert std.decimals(verb=PY2JSON, typ=Mystery, ctx=Fail()) is None
-    assert std.decimals(verb=INSP_JSON, typ=Mystery, ctx=Fail()) is None
-    assert std.decimals(verb=INSP_PY, typ=Mystery, ctx=Fail()) is None
+    assert std.decimals(verb="unknown", typ=date, ctx=Rules()) is None
+    assert std.decimals(verb=JSON2PY, typ=Mystery, ctx=Rules()) is None
+    assert std.decimals(verb=PY2JSON, typ=Mystery, ctx=Rules()) is None
+    assert std.decimals(verb=INSP_JSON, typ=Mystery, ctx=Rules()) is None
+    assert std.decimals(verb=INSP_PY, typ=Mystery, ctx=Rules()) is None
 
 
 def test_decimals():
     "Test the decimals rule will generate encoders and decoders for decimals."
 
-    decoder = std.decimals(verb=JSON2PY, typ=Decimal, ctx=Fail())
+    decoder = std.decimals(verb=JSON2PY, typ=Decimal, ctx=Rules())
     assert decoder(Decimal("77.7")) == Decimal("77.7")
 
-    encoder = std.decimals(verb=PY2JSON, typ=Decimal, ctx=Fail())
+    encoder = std.decimals(verb=PY2JSON, typ=Decimal, ctx=Rules())
     assert encoder(Decimal("77.7")) == Decimal("77.7")
 
-    inspect = std.decimals(verb=INSP_PY, typ=Decimal, ctx=Fail())
+    inspect = std.decimals(verb=INSP_PY, typ=Decimal, ctx=Rules())
     assert not inspect("string")
     assert not inspect(44)
     assert not inspect(77.7)
     assert not inspect("77.7")
     assert inspect(Decimal("77.7"))
 
-    inspect = std.decimals(verb=INSP_JSON, typ=Decimal, ctx=Fail())
+    inspect = std.decimals(verb=INSP_JSON, typ=Decimal, ctx=Rules())
     assert not inspect("string")
     assert not inspect(44)
     assert not inspect(77.7)
@@ -236,31 +247,31 @@ def test_decimals():
 def test_decimals_as_str_disregard():
     "Test the decimals_as_str rule will disregard unknown types and verbs."
 
-    assert std.decimals_as_str(verb="unknown", typ=date, ctx=Fail()) is None
-    assert std.decimals_as_str(verb=JSON2PY, typ=Mystery, ctx=Fail()) is None
-    assert std.decimals_as_str(verb=PY2JSON, typ=Mystery, ctx=Fail()) is None
-    assert std.decimals_as_str(verb=INSP_JSON, typ=Mystery, ctx=Fail()) is None
-    assert std.decimals_as_str(verb=INSP_PY, typ=Mystery, ctx=Fail()) is None
+    assert std.decimals_as_str(verb="unknown", typ=date, ctx=Rules()) is None
+    assert std.decimals_as_str(verb=JSON2PY, typ=Mystery, ctx=Rules()) is None
+    assert std.decimals_as_str(verb=PY2JSON, typ=Mystery, ctx=Rules()) is None
+    assert std.decimals_as_str(verb=INSP_JSON, typ=Mystery, ctx=Rules()) is None
+    assert std.decimals_as_str(verb=INSP_PY, typ=Mystery, ctx=Rules()) is None
 
 
 def test_decimals_as_str():
     "Test the decimals_as_str rule will generate encoders and decoders for decimals."
 
-    decoder = std.decimals_as_str(verb=JSON2PY, typ=Decimal, ctx=Fail())
+    decoder = std.decimals_as_str(verb=JSON2PY, typ=Decimal, ctx=Rules())
     assert decoder(Decimal("77.7")) == Decimal("77.7")
     assert decoder("77.7") == Decimal("77.7")
 
-    encoder = std.decimals_as_str(verb=PY2JSON, typ=Decimal, ctx=Fail())
+    encoder = std.decimals_as_str(verb=PY2JSON, typ=Decimal, ctx=Rules())
     assert encoder(Decimal("77.7")) == "77.7"
 
-    inspect = std.decimals_as_str(verb=INSP_PY, typ=Decimal, ctx=Fail())
+    inspect = std.decimals_as_str(verb=INSP_PY, typ=Decimal, ctx=Rules())
     assert not inspect("string")
     assert not inspect(44)
     assert not inspect(77.7)
     assert not inspect("77.7")
     assert inspect(Decimal("77.7"))
 
-    inspect = std.decimals_as_str(verb=INSP_JSON, typ=Decimal, ctx=Fail())
+    inspect = std.decimals_as_str(verb=INSP_JSON, typ=Decimal, ctx=Rules())
     assert not inspect("string")
     assert inspect(44)
     assert inspect(77.7)
@@ -271,32 +282,32 @@ def test_decimals_as_str():
 def test_iso_dates_disregard():
     "Test the iso_dates rule will disregard unknown types and verbs."
 
-    assert std.iso_dates(verb="unknown", typ=date, ctx=Fail()) is None
-    assert std.iso_dates(verb=JSON2PY, typ=Mystery, ctx=Fail()) is None
-    assert std.iso_dates(verb=PY2JSON, typ=Mystery, ctx=Fail()) is None
-    assert std.iso_dates(verb=INSP_JSON, typ=Mystery, ctx=Fail()) is None
-    assert std.iso_dates(verb=INSP_PY, typ=Mystery, ctx=Fail()) is None
+    assert std.iso_dates(verb="unknown", typ=date, ctx=Rules()) is None
+    assert std.iso_dates(verb=JSON2PY, typ=Mystery, ctx=Rules()) is None
+    assert std.iso_dates(verb=PY2JSON, typ=Mystery, ctx=Rules()) is None
+    assert std.iso_dates(verb=INSP_JSON, typ=Mystery, ctx=Rules()) is None
+    assert std.iso_dates(verb=INSP_PY, typ=Mystery, ctx=Rules()) is None
 
 
 def test_iso_dates():
     "Test the iso_dates rule handles dates using ISO8601, rejecting datetimes as input to dates."
 
-    decoder = std.iso_dates(verb=JSON2PY, typ=date, ctx=Fail())
+    decoder = std.iso_dates(verb=JSON2PY, typ=date, ctx=Rules())
     assert decoder("1776-07-04") == date(1776, 7, 4)
     with pytest.raises(ValueError):
         decoder("6543-02-01T09:09:09")
 
-    encoder = std.iso_dates(verb=PY2JSON, typ=date, ctx=Fail())
+    encoder = std.iso_dates(verb=PY2JSON, typ=date, ctx=Rules())
     assert encoder(date(1776, 7, 4)) == "1776-07-04"
 
-    inspect = std.iso_dates(verb=INSP_PY, typ=date, ctx=Fail())
+    inspect = std.iso_dates(verb=INSP_PY, typ=date, ctx=Rules())
     assert inspect(date(1776, 7, 4))
     assert not inspect(datetime(1776, 7, 4, 3, 3))
     assert not inspect("2000-01-01")
     assert not inspect("2000-01-01T03:03:03")
     assert not inspect("string")
 
-    inspect = std.iso_dates(verb=INSP_JSON, typ=date, ctx=Fail())
+    inspect = std.iso_dates(verb=INSP_JSON, typ=date, ctx=Rules())
     assert not inspect(date(1776, 7, 4))
     assert not inspect(datetime(1776, 7, 4, 3, 3))
     assert inspect("2000-01-01")
@@ -307,25 +318,25 @@ def test_iso_dates():
 def test_iso_datetimes():
     "Test the iso_dates rule will generate encoders and decoders for datetimes using ISO8601."
 
-    decoder = std.iso_dates(verb=JSON2PY, typ=datetime, ctx=Fail())
+    decoder = std.iso_dates(verb=JSON2PY, typ=datetime, ctx=Rules())
     assert decoder("6666-06-06T12:12:12.987654") == datetime(
         6666, 6, 6, 12, 12, 12, 987654
     )
 
-    encoder = std.iso_dates(verb=PY2JSON, typ=datetime, ctx=Fail())
+    encoder = std.iso_dates(verb=PY2JSON, typ=datetime, ctx=Rules())
     assert (
         encoder(datetime(6666, 6, 6, 12, 12, 12, 987654))
         == "6666-06-06T12:12:12.987654"
     )
 
-    inspect = std.iso_dates(verb=INSP_PY, typ=datetime, ctx=Fail())
+    inspect = std.iso_dates(verb=INSP_PY, typ=datetime, ctx=Rules())
     assert not inspect(date(1776, 7, 4))
     assert inspect(datetime(1776, 7, 4, 3, 3))
     assert not inspect("2000-01-01")
     assert not inspect("2000-01-01T03:03:03")
     assert not inspect("string")
 
-    inspect = std.iso_dates(verb=INSP_JSON, typ=datetime, ctx=Fail())
+    inspect = std.iso_dates(verb=INSP_JSON, typ=datetime, ctx=Rules())
     assert not inspect(date(1776, 7, 4))
     assert not inspect(datetime(1776, 7, 4, 3, 3))
     assert inspect("2000-01-01")
@@ -337,7 +348,7 @@ def test_iso_dates_picklable():
     "Test that actions generated by the iso_dates rule can be pickled."
 
     actions = [
-        std.iso_dates(verb=verb, typ=typ, ctx=Fail())
+        std.iso_dates(verb=verb, typ=typ, ctx=Rules())
         for verb in [JSON2PY, PY2JSON]
         for typ in [date, datetime]
     ]
@@ -360,28 +371,28 @@ class Enum2(IntEnum):
 def test_enums_disregard():
     "Test the iso_dates rule will disregard unknown types and verbs."
 
-    assert std.enums(verb="unknown", typ=Enum1, ctx=Fail()) is None
-    assert std.enums(verb=JSON2PY, typ=Mystery, ctx=Fail()) is None
-    assert std.enums(verb=PY2JSON, typ=Mystery, ctx=Fail()) is None
+    assert std.enums(verb="unknown", typ=Enum1, ctx=Rules()) is None
+    assert std.enums(verb=JSON2PY, typ=Mystery, ctx=Rules()) is None
+    assert std.enums(verb=PY2JSON, typ=Mystery, ctx=Rules()) is None
 
 
 def test_enums():
     "Test the enums rule will generate encoders and decoders for enumerated types."
 
-    decoder = std.enums(verb=JSON2PY, typ=Enum1, ctx=Fail())
+    decoder = std.enums(verb=JSON2PY, typ=Enum1, ctx=Rules())
     assert decoder("ABLE") == Enum1.ABLE
     assert decoder("CHARLIE") == Enum1.CHARLIE
 
-    encoder = std.enums(verb=PY2JSON, typ=Enum1, ctx=Fail())
+    encoder = std.enums(verb=PY2JSON, typ=Enum1, ctx=Rules())
     assert encoder(Enum1.BAKER) == "BAKER"
     assert encoder(Enum1.CHARLIE) == "CHARLIE"
 
-    inspect = std.enums(verb=INSP_PY, typ=Enum1, ctx=Fail())
+    inspect = std.enums(verb=INSP_PY, typ=Enum1, ctx=Rules())
     assert not inspect("ABLE")
     assert inspect(Enum1.CHARLIE)
     assert not inspect(Enum2.BETA)
 
-    inspect = std.enums(verb=INSP_JSON, typ=Enum1, ctx=Fail())
+    inspect = std.enums(verb=INSP_JSON, typ=Enum1, ctx=Rules())
     assert not inspect(Enum1.BAKER)
     assert not inspect("BETA")
     assert inspect("CHARLIE")
@@ -389,20 +400,20 @@ def test_enums():
 
 def test_enums_int():
     "Test the enums rule will generate encoders and decoders for enumerated type subclasses."
-    decoder = std.enums(verb=JSON2PY, typ=Enum2, ctx=Fail())
+    decoder = std.enums(verb=JSON2PY, typ=Enum2, ctx=Rules())
     assert decoder("ALPHA") == Enum2.ALPHA
     assert decoder("GAMMA") == Enum2.GAMMA
 
-    encoder = std.enums(verb=PY2JSON, typ=Enum2, ctx=Fail())
+    encoder = std.enums(verb=PY2JSON, typ=Enum2, ctx=Rules())
     assert encoder(Enum2.BETA) == "BETA"
     assert encoder(Enum2.GAMMA) == "GAMMA"
 
-    inspect = std.enums(verb=INSP_PY, typ=Enum2, ctx=Fail())
+    inspect = std.enums(verb=INSP_PY, typ=Enum2, ctx=Rules())
     assert not inspect("ALPA")
     assert not inspect(Enum1.CHARLIE)
     assert inspect(Enum2.BETA)
 
-    inspect = std.enums(verb=INSP_JSON, typ=Enum2, ctx=Fail())
+    inspect = std.enums(verb=INSP_JSON, typ=Enum2, ctx=Rules())
     assert not inspect(Enum2.GAMMA)
     assert inspect("BETA")
     assert not inspect("ABLE")
@@ -412,7 +423,7 @@ def test_enums_picklable():
     "Test that actions generated by the enums rule can be pickled."
 
     actions = [
-        std.enums(verb=verb, typ=typ, ctx=Fail())
+        std.enums(verb=verb, typ=typ, ctx=Rules())
         for verb in [JSON2PY, PY2JSON, INSP_PY, INSP_JSON]
         for typ in [Enum1, Enum2]
     ]
@@ -423,30 +434,30 @@ def test_enums_picklable():
 def test_faux_enums_disregard():
     "Test the iso_dates rule will disregard unknown types and verbs."
 
-    assert std.faux_enums(verb="unknown", typ=Enum1, ctx=Fail()) is None
-    assert std.faux_enums(verb=JSON2PY, typ=Mystery, ctx=Fail()) is None
-    assert std.faux_enums(verb=PY2JSON, typ=Mystery, ctx=Fail()) is None
+    assert std.faux_enums(verb="unknown", typ=Enum1, ctx=Rules()) is None
+    assert std.faux_enums(verb=JSON2PY, typ=Mystery, ctx=Rules()) is None
+    assert std.faux_enums(verb=PY2JSON, typ=Mystery, ctx=Rules()) is None
 
 
 def test_faux_enums():
     "Test the enums rule will generate encoders and decoders for enumerated types."
 
-    decoder = std.faux_enums(verb=JSON2PY, typ=Enum1, ctx=Fail())
+    decoder = std.faux_enums(verb=JSON2PY, typ=Enum1, ctx=Rules())
     assert decoder("ABLE") == "ABLE"
     with pytest.raises(KeyError):
         decoder("OTHER")
 
-    encoder = std.faux_enums(verb=PY2JSON, typ=Enum1, ctx=Fail())
+    encoder = std.faux_enums(verb=PY2JSON, typ=Enum1, ctx=Rules())
     assert encoder("BAKER") == "BAKER"
     with pytest.raises(KeyError):
         encoder("OTHER")
 
-    inspect = std.faux_enums(verb=INSP_PY, typ=Enum1, ctx=Fail())
+    inspect = std.faux_enums(verb=INSP_PY, typ=Enum1, ctx=Rules())
     assert inspect("ABLE")
     assert not inspect(Enum1.CHARLIE)
     assert not inspect(Enum2.BETA)
 
-    inspect = std.faux_enums(verb=INSP_JSON, typ=Enum1, ctx=Fail())
+    inspect = std.faux_enums(verb=INSP_JSON, typ=Enum1, ctx=Rules())
     assert not inspect(Enum1.BAKER)
     assert not inspect("BETA")
     assert inspect("CHARLIE")
@@ -456,7 +467,7 @@ def test_faux_enums_picklable():
     "Test that actions generated by the enums rule can be pickled."
 
     actions = [
-        std.faux_enums(verb=verb, typ=typ, ctx=Fail())
+        std.faux_enums(verb=verb, typ=typ, ctx=Rules())
         for verb in [JSON2PY, PY2JSON, INSP_PY, INSP_JSON]
         for typ in [Enum1, Enum2]
     ]
@@ -467,17 +478,19 @@ def test_faux_enums_picklable():
 def test_optional_disregard():
     "Test that optional will disregard unknown types and verbs."
 
-    assert std.optional(verb="unknown", typ=Optional[int], ctx=Fail()) is None
-    assert std.optional(verb=JSON2PY, typ=Union[int, str], ctx=Fail()) is None
-    assert std.optional(verb=JSON2PY, typ=Union[int, str, NoneType], ctx=Fail()) is None
-    assert std.optional(verb=JSON2PY, typ=Mystery, ctx=Fail()) is None
-    assert std.optional(verb=PY2JSON, typ=Mystery, ctx=Fail()) is None
+    assert std.optional(verb="unknown", typ=Optional[int], ctx=Rules()) is None
+    assert std.optional(verb=JSON2PY, typ=Union[int, str], ctx=Rules()) is None
+    assert (
+        std.optional(verb=JSON2PY, typ=Union[int, str, NoneType], ctx=Rules()) is None
+    )
+    assert std.optional(verb=JSON2PY, typ=Mystery, ctx=Rules()) is None
+    assert std.optional(verb=PY2JSON, typ=Mystery, ctx=Rules()) is None
 
 
 def test_optional():
     "Test that optional returns a action that pass non-null values to an inner action."
 
-    ctx = Mock(lookup=Mock(return_value=int))
+    ctx = Rules(std.atoms)
 
     encoder = std.optional(verb=PY2JSON, typ=Optional[int], ctx=ctx)
     assert encoder("77") == 77
@@ -486,8 +499,6 @@ def test_optional():
     decoder = std.optional(verb=JSON2PY, typ=Optional[int], ctx=ctx)
     assert decoder("77") == 77
     assert decoder(None) is None
-
-    ctx = Mock(lookup=Mock(return_value=lambda val: isinstance(val, int)))
 
     inspect = std.optional(verb=INSP_PY, typ=Optional[int], ctx=ctx)
     assert inspect(77)
@@ -503,7 +514,7 @@ def test_optional():
 def test_optional_nonstandard():
     "Test that optional recognizes Unions that are effectively Optional."
 
-    ctx = Mock(lookup=Mock(return_value=str))
+    ctx = Rules(std.atoms)
 
     encoder = std.optional(verb=PY2JSON, typ=Union[str, NoneType], ctx=ctx)
     assert encoder(77) == "77"
@@ -517,7 +528,7 @@ def test_optional_nonstandard():
 def test_optional_invalid():
     "Test that optional raises if no valid inner type is found."
 
-    ctx = Mock(lookup=Mock(return_value=str))
+    ctx = Rules(std.atoms)
     fake_type = Mock(__origin__=Union, __args__=(NoneType, NoneType))
 
     for verb in (JSON2PY, PY2JSON, INSP_PY, INSP_JSON):
@@ -528,7 +539,7 @@ def test_optional_invalid():
 def test_optional_picklable():
     "Test that actions generated by the optional rule can be pickled."
 
-    ctx = Mock(lookup=partial(std.atoms, ctx=Fail()))
+    ctx = Rules(std.atoms, std.floats)
 
     actions = [
         std.optional(verb=verb, typ=typ, ctx=ctx)
@@ -542,26 +553,24 @@ def test_optional_picklable():
 def test_lists_disregards():
     "Test that lists disregards unknown types and verbs."
 
-    assert std.lists(verb="unknown", typ=List[int], ctx=Fail()) is None
-    assert std.lists(verb="unknown", typ=Tuple[int, ...], ctx=Fail()) is None
-    assert std.lists(verb=PY2JSON, typ=bool, ctx=Fail()) is None
-    assert std.lists(verb=JSON2PY, typ=Tuple[int, str], ctx=Fail()) is None
-    assert std.lists(verb=INSP_PY, typ=bool, ctx=Fail()) is None
-    assert std.lists(verb=INSP_JSON, typ=Tuple[int, str], ctx=Fail()) is None
+    assert std.lists(verb="unknown", typ=List[int], ctx=Rules()) is None
+    assert std.lists(verb="unknown", typ=Tuple[int, ...], ctx=Rules()) is None
+    assert std.lists(verb=PY2JSON, typ=bool, ctx=Rules()) is None
+    assert std.lists(verb=JSON2PY, typ=Tuple[int, str], ctx=Rules()) is None
+    assert std.lists(verb=INSP_PY, typ=bool, ctx=Rules()) is None
+    assert std.lists(verb=INSP_JSON, typ=Tuple[int, str], ctx=Rules()) is None
 
 
 def test_lists_lists():
     "Test that lists will generate encoders and decoders for lists."
 
-    ctx = Mock(lookup=Mock(return_value=str))
+    ctx = Rules(std.atoms)
 
     encoder = std.lists(verb=PY2JSON, typ=List[str], ctx=ctx)
     assert encoder([33, 77]) == ["33", "77"]
 
     decoder = std.lists(verb=JSON2PY, typ=List[str], ctx=ctx)
     assert decoder([33, 77]) == ["33", "77"]
-
-    ctx = Mock(lookup=Mock(return_value=lambda val: isinstance(val, str)))
 
     inspect = std.lists(verb=INSP_PY, typ=List[str], ctx=ctx)
     assert not inspect(["33", 77])
@@ -577,15 +586,13 @@ def test_lists_lists():
 def test_lists_tuples():
     "Test that lists will generate encoders and decoders for homogenous tuples."
 
-    ctx = Mock(lookup=Mock(return_value=str))
+    ctx = Rules(std.atoms)
 
     encoder = std.lists(verb=PY2JSON, typ=Tuple[str, ...], ctx=ctx)
     assert encoder((33, 77)) == ["33", "77"]
 
     decoder = std.lists(verb=JSON2PY, typ=Tuple[str, ...], ctx=ctx)
     assert decoder([33, 77]) == ("33", "77")
-
-    ctx = Mock(lookup=Mock(return_value=lambda val: isinstance(val, str)))
 
     inspect = std.lists(verb=INSP_PY, typ=Tuple[str, ...], ctx=ctx)
     assert not inspect(("33", 77))
@@ -604,18 +611,18 @@ def test_lists_tuples():
 def test_sets_disregards():
     "Test that sets disregards unknown types and verbs."
 
-    assert std.sets(verb="unknown", typ=Set[int], ctx=Fail()) is None
-    assert std.sets(verb="unknown", typ=FrozenSet[set], ctx=Fail()) is None
-    assert std.sets(verb=PY2JSON, typ=bool, ctx=Fail()) is None
-    assert std.sets(verb=JSON2PY, typ=List[str], ctx=Fail()) is None
-    assert std.sets(verb=INSP_PY, typ=bool, ctx=Fail()) is None
-    assert std.sets(verb=INSP_JSON, typ=List[str], ctx=Fail()) is None
+    assert std.sets(verb="unknown", typ=Set[int], ctx=Rules()) is None
+    assert std.sets(verb="unknown", typ=FrozenSet[set], ctx=Rules()) is None
+    assert std.sets(verb=PY2JSON, typ=bool, ctx=Rules()) is None
+    assert std.sets(verb=JSON2PY, typ=List[str], ctx=Rules()) is None
+    assert std.sets(verb=INSP_PY, typ=bool, ctx=Rules()) is None
+    assert std.sets(verb=INSP_JSON, typ=List[str], ctx=Rules()) is None
 
 
 def test_sets_sets():
     "Test that sets will generate encoders and decoders for sets."
 
-    ctx = Mock(lookup=Mock(return_value=str))
+    ctx = Rules(std.atoms)
 
     encoder = std.sets(verb=PY2JSON, typ=Set[str], ctx=ctx)
     actual = encoder({1, 2, 2, 3})
@@ -624,8 +631,6 @@ def test_sets_sets():
 
     decoder = std.sets(verb=JSON2PY, typ=Set[str], ctx=ctx)
     assert decoder([1, 2, 2, 3]) == {"1", "2", "3"}
-
-    ctx = Mock(lookup=Mock(return_value=lambda val: isinstance(val, str)))
 
     inspect = std.sets(verb=INSP_PY, typ=Set[str], ctx=ctx)
     assert not inspect({"33", 77})
@@ -641,7 +646,7 @@ def test_sets_sets():
 def test_sets_frozen():
     "Test that sets will generate encoders and decoders for frozen sets."
 
-    ctx = Mock(lookup=Mock(return_value=str))
+    ctx = Rules(std.atoms)
 
     encoder = std.sets(verb=PY2JSON, typ=FrozenSet[str], ctx=ctx)
     actual = encoder(frozenset([1, 2, 2, 3]))
@@ -650,8 +655,6 @@ def test_sets_frozen():
 
     decoder = std.sets(verb=JSON2PY, typ=FrozenSet[str], ctx=ctx)
     assert decoder([1, 2, 2, 3]) == frozenset(["1", "2", "3"])
-
-    ctx = Mock(lookup=Mock(return_value=lambda val: isinstance(val, str)))
 
     inspect = std.sets(verb=INSP_PY, typ=FrozenSet[str], ctx=ctx)
     assert not inspect(frozenset({"33", 77}))
@@ -667,33 +670,32 @@ def test_sets_frozen():
 def test_dicts_disregards():
     "Test that dicts disregards unknown types and verbs."
 
-    assert std.dicts(verb="unknown", typ=Dict[str, int], ctx=Fail()) is None
-    assert std.dicts(verb="unknown", typ=Dict[date, float], ctx=Fail()) is None
+    ctx = Rules(stringify_keys, std.atoms, std.floats)
+
+    assert std.dicts(verb="unknown", typ=Dict[str, int], ctx=ctx) is None
+    assert std.dicts(verb="unknown", typ=Dict[datetime, float], ctx=ctx) is None
     if OrderedDict is not None:
-        assert std.dicts(verb="unknown", typ=OrderedDict[str, int], ctx=Fail()) is None
+        assert std.dicts(verb="unknown", typ=OrderedDict[str, int], ctx=ctx) is None
         assert (
-            std.dicts(verb="unknown", typ=OrderedDict[date, float], ctx=Fail()) is None
+            std.dicts(verb="unknown", typ=OrderedDict[datetime, float], ctx=ctx) is None
         )
-    assert std.dicts(verb=PY2JSON, typ=bool, ctx=Fail()) is None
-    assert std.dicts(verb=JSON2PY, typ=Dict[float, str], ctx=Fail()) is None
-    assert std.dicts(verb=INSP_PY, typ=Dict[float, str], ctx=Fail()) is None
-    assert std.dicts(verb=INSP_JSON, typ=List[str], ctx=Fail()) is None
+    assert std.dicts(verb=PY2JSON, typ=bool, ctx=ctx) is None
+    with pytest.raises(RuntimeError):
+        std.dicts(verb=JSON2PY, typ=Dict[float, str], ctx=ctx)
+
+    assert std.dicts(verb=INSP_JSON, typ=List[str], ctx=ctx) is None
 
 
 def test_dicts_string_key():
     "Test that dicts will generate encoders and decoders for dicts."
 
-    ctx = Mock(lookup=Mock(side_effect=lambda verb, typ: typ))
+    ctx = Rules(stringify_keys, std.atoms)
 
     encoder = std.dicts(verb=PY2JSON, typ=Dict[str, int], ctx=ctx)
     assert encoder({22: "11", 44: "33"}) == {"22": 11, "44": 33}
 
     decoder = std.dicts(verb=JSON2PY, typ=Dict[str, int], ctx=ctx)
     assert decoder({22: "11", 44: "33"}) == {"22": 11, "44": 33}
-
-    ctx = Mock(
-        lookup=Mock(side_effect=lambda verb, typ: lambda val: isinstance(val, typ))
-    )
 
     inspect = std.dicts(verb=INSP_PY, typ=Dict[str, int], ctx=ctx)
     assert not inspect({"foo": 1, "bar": "no"})
@@ -706,6 +708,34 @@ def test_dicts_string_key():
     assert inspect({})
 
 
+def test_dicts_date_key():
+    "Test that dicts will generate encoders and decoders for dicts with simple dates as keys."
+
+    ctx = Rules(std.atoms, std.iso_dates, stringify_keys)
+
+    encoder = std.dicts(verb=PY2JSON, typ=Dict[date, int], ctx=ctx)
+    assert encoder({date(2020, 2, 22): "11", date(2040, 4, 4): "33"}) == {
+        "2020-02-22": 11,
+        "2040-04-04": 33,
+    }
+
+    decoder = std.dicts(verb=JSON2PY, typ=Dict[date, int], ctx=ctx)
+    assert decoder({"2020-02-22": "11", "2040-04-04": "33"}) == {
+        date(2020, 2, 22): 11,
+        date(2040, 4, 4): 33,
+    }
+
+    inspect = std.dicts(verb=INSP_PY, typ=Dict[date, int], ctx=ctx)
+    assert not inspect({date(2040, 4, 4): 1, date(2020, 2, 22): "no"})
+    assert inspect({date(2040, 4, 4): 1, date(2020, 2, 22): 2})
+    assert inspect({})
+
+    inspect = std.dicts(verb=INSP_JSON, typ=Dict[date, int], ctx=ctx)
+    assert not inspect({"2011-11-11": 1, "2022-02-02": "no"})
+    assert inspect({"2011-11-11": 1, "2022-02-02": 2})
+    assert inspect({})
+
+
 class AB(Enum):
     A = 1
     B = 2
@@ -714,17 +744,13 @@ class AB(Enum):
 def test_dicts_enum_key():
     "Test that dicts will generate encoders and decoders for dicts."
 
-    ctx = Mock(lookup=Mock(side_effect=lambda verb, typ: typ))
+    ctx = Rules(stringify_keys, std.atoms, std.enums)
 
     encoder = std.dicts(verb=PY2JSON, typ=Dict[AB, int], ctx=ctx)
     assert encoder({AB.A: "11", AB.B: "33"}) == {"A": 11, "B": 33}
 
     decoder = std.dicts(verb=JSON2PY, typ=Dict[AB, int], ctx=ctx)
     assert decoder({"A": "11", "B": "33"}) == {AB.A: 11, AB.B: 33}
-
-    ctx = Mock(
-        lookup=Mock(side_effect=lambda verb, typ: lambda val: isinstance(val, typ))
-    )
 
     inspect = std.dicts(verb=INSP_PY, typ=Dict[AB, int], ctx=ctx)
     assert not inspect({AB.A: 1, AB.B: "no"})


### PR DESCRIPTION
- Drop read_all as we shouldn't try to save `init=False` keys in attrs.
- Make sure helpers._Context is stringifying context items.
- Bump version to 2.1.0.